### PR TITLE
rest-retreat-final

### DIFF
--- a/api/send-inquiry.js
+++ b/api/send-inquiry.js
@@ -1,0 +1,55 @@
+// Vercel serverless function to handle retreat inquiry emails via SendGrid.
+// Requires environment variables: SENDGRID_API_KEY, INQUIRY_TO and (optional) INQUIRY_FROM.
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ ok: false, error: 'Method Not Allowed' });
+  }
+  const { tier, name, email, honeypot } = req.body || {};
+  // basic honeypot to deter bots; if present, silently succeed
+  if (honeypot) {
+    return res.status(200).json({ ok: true });
+  }
+  if (!tier || !name || !email) {
+    return res.status(400).json({ ok: false, error: 'Missing required fields.' });
+  }
+  const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY;
+  const toEmail = process.env.INQUIRY_TO || 'info@incluu.us';
+  const fromEmail = process.env.INQUIRY_FROM || 'info@incluu.us';
+  if (!SENDGRID_API_KEY) {
+    return res.status(500).json({ ok: false, error: 'Missing SENDGRID_API_KEY' });
+  }
+  const payload = {
+    personalizations: [
+      {
+        to: [ { email: toEmail } ],
+        subject: `RAR Retreat Inquiry — ${tier}`
+      }
+    ],
+    from: { email: fromEmail, name: 'RAR Retreat' },
+    reply_to: { email },
+    content: [
+      {
+        type: 'text/html',
+        value: `<h2>New Retreat Inquiry</h2>\n<p><strong>Selected Tier:</strong> ${tier}</p>\n<p><strong>Name:</strong> ${name}</p>\n<p><strong>Email:</strong> ${email}</p>`
+      }
+    ]
+  };
+  try {
+    const resp = await fetch('https://api.sendgrid.com/v3/mail/send', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${SENDGRID_API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+    if (!resp.ok) {
+      const errText = await resp.text();
+      return res.status(500).json({ ok: false, error: errText || 'SendGrid error' });
+    }
+    return res.status(200).json({ ok: true });
+  } catch (err) {
+    return res.status(500).json({ ok: false, error: err.message || 'Server error' });
+  }
+}

--- a/index.html
+++ b/index.html
@@ -414,7 +414,34 @@
           </details>
           <details class="faq-item">
             <summary>What’s included in the price?</summary>
-            <p>Your journey covers lodging, intercity transport, daily onsen rituals, workshops, curated meals and concierge support. International airfare, visas, travel insurance and add‑ons are extra.</p>
+            <!-- Updated pricing FAQ to include flights after September 15 and detailed tier breakdown -->
+            <p>Your journey covers lodging, intercity transport, daily onsen rituals, workshops, curated meals and concierge support. International airfare, visas, travel insurance and add‑ons are extra. International airfare (return) is included after&nbsp;9/15, once the Early Bird Pricing period ends.</p>
+            <p><br></p>
+            <p><strong>Retreat Pricing (Flights Included) — After September 15</strong></p>
+            <ul class="pricing-list">
+              <li><strong>Whispering Pines: $8,700 USD</strong>
+                <ul>
+                  <li>Double/shared occupancy</li>
+                  <li>All retreat activities &amp; meals</li>
+                  <li>Round‑trip airfare</li>
+                </ul>
+              </li>
+              <li><strong>Golden Crane: $11,200 USD</strong>
+                <ul>
+                  <li>Private room upgrade &amp; premium amenities</li>
+                  <li>All retreat activities &amp; meals</li>
+                  <li>Round‑trip airfare</li>
+                </ul>
+              </li>
+              <li><strong>Eternal Blossom: $13,500 USD</strong>
+                <ul>
+                  <li>Single occupancy &amp; maximum privacy</li>
+                  <li>Exclusive spa treatment</li>
+                  <li>All retreat activities &amp; meals</li>
+                  <li>Round‑trip airfare</li>
+                </ul>
+              </li>
+            </ul>
           </details>
           <details class="faq-item">
             <summary>How do I secure my spot?</summary>
@@ -422,7 +449,7 @@
           </details>
           <details class="faq-item">
             <summary>What if I need to cancel?</summary>
-            <p>We understand plans change. Deposits are refundable up to 90 days before departure, minus a small administrative fee. If you need to cancel after that, we’ll work with you on a case‑by‑case basis.</p>
+            <p>We understand plans change. Deposits are refundable up to 60 days before departure, minus a small administrative fee. If you need to cancel after that, we’ll work with you on a case‑by‑case basis.</p>
           </details>
           <!-- Additional FAQs added for potential guest questions -->
           <details class="faq-item">

--- a/script.js
+++ b/script.js
@@ -30,4 +30,78 @@ document.addEventListener('DOMContentLoaded', () => {
 
   updateCountdown();
   setInterval(updateCountdown, 1000);
+
+  // --- Reservation and Inquiry form logic ---
+  // Mapping of journey values to Stripe checkout links. These links correspond
+  // to the “Pay Deposit” buttons in the pricing cards. Updating the values
+  // here ensures the Reserve Now button always opens the correct checkout.
+  const depositLinks = {
+    'whispering-pines': 'https://buy.stripe.com/00wfZh2uq8jH6GG3GV7kc01',
+    'golden-crane': 'https://buy.stripe.com/aFaaEX5GCdE14yy4KZ7kc03',
+    'eternal-blossom': 'https://buy.stripe.com/fZucN53yu0Rf0ii6T77kc05'
+  };
+
+  const journeySelect = document.getElementById('journey-select');
+  const reserveBtn = document.getElementById('payment-button');
+
+  function updateReserveLink() {
+    const journey = journeySelect.value;
+    const url = depositLinks[journey] || '#';
+    // Set the click handler to open Stripe in a new tab
+    reserveBtn.onclick = () => {
+      if (url && url !== '#') {
+        window.open(url, '_blank', 'noopener');
+      }
+    };
+  }
+
+  if (journeySelect && reserveBtn) {
+    journeySelect.addEventListener('change', updateReserveLink);
+    updateReserveLink();
+  }
+
+  // Handle Send Inquiry submission
+  const inquiryBtn = document.querySelector('.form-actions .secondary-btn');
+  if (inquiryBtn && journeySelect) {
+    inquiryBtn.addEventListener('click', async () => {
+      const nameInput = document.getElementById('full-name');
+      const emailInput = document.getElementById('email');
+      const name = nameInput.value.trim();
+      const email = emailInput.value.trim();
+      const tierOption = journeySelect.options[journeySelect.selectedIndex].text;
+      const tierName = tierOption.split('—')[0].trim();
+
+      if (!name || !email) {
+        alert('Please enter your name and email.');
+        return;
+      }
+
+      inquiryBtn.disabled = true;
+      const originalText = inquiryBtn.textContent;
+      inquiryBtn.textContent = 'Sending…';
+
+      try {
+        const response = await fetch('/api/send-inquiry', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tier: tierName, name, email, honeypot: '' })
+        });
+        const data = await response.json();
+        if (data && data.ok) {
+          inquiryBtn.textContent = 'Sent!';
+          // Reset form fields
+          nameInput.value = '';
+          emailInput.value = '';
+        } else {
+          inquiryBtn.disabled = false;
+          inquiryBtn.textContent = originalText;
+          alert(data.error || 'There was an issue sending your inquiry. Please try again.');
+        }
+      } catch (err) {
+        inquiryBtn.disabled = false;
+        inquiryBtn.textContent = originalText;
+        alert('Network error. Please try again.');
+      }
+    });
+  }
 });

--- a/styles.css
+++ b/styles.css
@@ -838,3 +838,20 @@ details.faq-item > summary::after {
   .hero-subtitle { font-size: 0.85rem !important; }
 }
 
+/* Pricing list styling for the FAQ pricing breakdown */
+.pricing-list,
+.pricing-list ul {
+  font-size: 0.85rem;
+  margin-left: 1.2rem;
+  line-height: 1.4;
+  list-style-type: disc;
+}
+
+.pricing-list > li {
+  margin-bottom: 0.7rem;
+}
+
+.pricing-list strong {
+  font-weight: 600;
+}
+


### PR DESCRIPTION
The new bundle is ready. I’ve restored the countdown timer, corrected the FAQ formatting (with a dedicated bullet list for the post‑September 15 pricing), updated the refund policy to 60 days, and wired up the “Reserve Now” and “Send Inquiry” buttons correctly via a SendGrid‑powered API route. Everything is packaged in a complete, ready‑to‑deploy zip file.

Key fixes included:

Countdown clock is back and counting toward September 15, 2025.

FAQ pricing list displays as a well‑spaced, indented bulleted list; the text size is smaller for legibility.

Added a blank line between “Early Bird Pricing period ends…” and the pricing list.

Changed deposit refund from 90 days to 60 days.

Send inquiry form now posts to /api/send-inquiry (SendGrid handler) with error handling.

“Reserve Now” button reads the correct Stripe checkout link based on the selected journey.

New CSS styles for the nested pricing list.

Created /api/send-inquiry.js to send emails from info@incluu.us using your SENDGRID_API_KEY.

You can download the complete site here: rest_retreat_final.zip Unzip, replace your existing files with the contents of final-site, and redeploy via Vercel. Don’t forget to add SENDGRID_API_KEY and (optionally) INQUIRY_TO/INQUIRY_FROM in your Vercel environment variables.