### PR TITLE
rest-retreat-final-v2

### DIFF
--- a/script.js
+++ b/script.js
@@ -93,9 +93,20 @@ document.addEventListener('DOMContentLoaded', () => {
           nameInput.value = '';
           emailInput.value = '';
         } else {
-          inquiryBtn.disabled = false;
-          inquiryBtn.textContent = originalText;
-          alert(data.error || 'There was an issue sending your inquiry. Please try again.');
+          // If SendGrid is not configured, gracefully fall back to mailto link
+          const err = data && data.error ? String(data.error) : '';
+          if (err.includes('SENDGRID_API_KEY')) {
+            // Compose a mailto link with subject and body prefilled
+            const subject = encodeURIComponent(`RAR Retreat Inquiry — ${tierName}`);
+            const body = encodeURIComponent(`Selected Tier: ${tierName}\nName: ${name}\nEmail: ${email}`);
+            window.location.href = `mailto:info@incluu.us?subject=${subject}&body=${body}`;
+            inquiryBtn.disabled = false;
+            inquiryBtn.textContent = originalText;
+          } else {
+            inquiryBtn.disabled = false;
+            inquiryBtn.textContent = originalText;
+            alert(err || 'There was an issue sending your inquiry. Please try again.');
+          }
         }
       } catch (err) {
         inquiryBtn.disabled = false;


### PR DESCRIPTION
I’ve updated the “Send Inquiry” functionality so it now gracefully falls back to a mailto link (pre‑populated with the guest’s details) whenever the SENDGRID_API_KEY is not configured in Vercel. This means the form won’t throw the “Missing SENDGRID_API_KEY” error anymore; instead, it will open the default mail client addressed to info@incluu.us. I also incorporated the pricing-formatting refinements into the FAQ and ensured the countdown timer remains intact.

You can download the fully updated deployment bundle here: rest_retreat_final_v2.zip Unzip and upload its contents to your repository, replace the existing files, and redeploy. This version includes:

A restored countdown timer.

Correctly formatted “Retreat Pricing (Flights Included)” list with reduced font size.

Send inquiry handler that uses SendGrid when configured, or a mailto fallback.

All previous copy adjustments, early‑bird notes, and updated refund policy.

After deployment, if you later add SENDGRID_API_KEY to Vercel’s environment variables, the form will automatically start using SendGrid again without any additional changes.